### PR TITLE
Add efs filesystem policy

### DIFF
--- a/recipes/storage/efs_simple/assets/main.yaml
+++ b/recipes/storage/efs_simple/assets/main.yaml
@@ -35,7 +35,22 @@ Resources:
     Type: AWS::EFS::FileSystem
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
-    Properties: 
+    Properties:
+      FileSystemPolicy:
+        Version: 2012-10-17
+        Id: efs-prevent-anonymous-access-policy
+        Statement:
+          - Sid: efs-statement
+            Effect: Allow
+            Principal:
+              AWS: '*'
+            Action:
+              - 'elasticfilesystem:ClientRootAccess'
+              - 'elasticfilesystem:ClientWrite'
+              - 'elasticfilesystem:ClientMount'
+            Condition:
+              Bool:
+                'elasticfilesystem:AccessedViaMountTarget': 'true'
       BackupPolicy: 
         Status: !Ref AutomaticBackups
       Encrypted: false


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Allow the specified EFS actions to clients accessing the EFS file system using a file system mount target
Reference: https://docs.aws.amazon.com/efs/latest/ug/access-control-block-public-access.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
