### PR TITLE
Add DHCP Option Set to VPC to use AD servers as the primary DNS servers

### DIFF
--- a/recipes/dir/demo_managed_ad/assets/main-import.yaml
+++ b/recipes/dir/demo_managed_ad/assets/main-import.yaml
@@ -314,13 +314,6 @@ Resources:
               echo "Domain Name: ${DirectoryDomain}"
               echo "Domain Certificate Secret: ${DomainCertificateSecretArn}"
               echo "Domain Private Key Secret: ${DomainPrivateKeySecretArn}"
-              cat << EOF > /etc/resolv.conf
-              search           ${DirectoryDomain}
-              nameserver       ${DnsIp1}
-              nameserver       ${DnsIp2}
-              EOF
-              sed -i 's/PEERDNS=.*/PEERDNS=no/' /etc/sysconfig/network-scripts/ifcfg-eth0
-              chattr +i /etc/resolv.conf
               ADMIN_PW="${AdminPassword}"
               echo "$ADMIN_PW" | sudo realm join -U Admin "${DirectoryDomain}"
               sleep 10
@@ -357,14 +350,26 @@ Resources:
             - { DirectoryDomain: !GetAtt Prep.DomainName,
                 AdminPassword: !Ref AdminPassword,
                 UserName: !Ref UserName,
-                DnsIp1: !GetAtt Prep.DnsIpAddress1,
-                DnsIp2: !GetAtt Prep.DnsIpAddress2,
                 DomainCertificateSecretArn: !Ref DomainCertificateSecret,
                 DomainPrivateKeySecretArn: !Ref DomainPrivateKeySecret,
                 LDIFS3Path: !Ref LDIFS3Path,
                 DC: !Join [",dc=", !Split [".", !Ref DomainName ]],
                 OU: !GetAtt Prep.DomainShortName
             }
+
+  DhcpOptions:
+    Type: AWS::EC2::DHCPOptions
+    Properties:
+      DomainName: !Ref DomainName
+      DomainNameServers: 
+        - !GetAtt Prep.DnsIpAddress1
+        - !GetAtt Prep.DnsIpAddress2
+
+  VPCDHCPOptionsAssociation:
+    Type: AWS::EC2::VPCDHCPOptionsAssociation
+    Properties: 
+      DhcpOptionsId: !GetAtt DhcpOptions.DhcpOptionsId
+      VpcId: {"Fn::ImportValue" : {"Fn::Sub" : "${NetworkStackNameParameter}-VPC"}}
 
   PostRole:
     Type: AWS::IAM::Role

--- a/recipes/dir/demo_managed_ad/assets/main.yaml
+++ b/recipes/dir/demo_managed_ad/assets/main.yaml
@@ -417,13 +417,6 @@ Resources:
               echo "Domain Name: ${DirectoryDomain}"
               echo "Domain Certificate Secret: ${DomainCertificateSecretArn}"
               echo "Domain Private Key Secret: ${DomainPrivateKeySecretArn}"
-              cat << EOF > /etc/resolv.conf
-              search           ${DirectoryDomain}
-              nameserver       ${DnsIp1}
-              nameserver       ${DnsIp2}
-              EOF
-              sed -i 's/PEERDNS=.*/PEERDNS=no/' /etc/sysconfig/network-scripts/ifcfg-eth0
-              chattr +i /etc/resolv.conf
               ADMIN_PW="${AdminPassword}"
               echo "$ADMIN_PW" | sudo realm join -U Admin "${DirectoryDomain}"
               sleep 10
@@ -460,8 +453,6 @@ Resources:
             - { DirectoryDomain: !GetAtt Prep.DomainName,
                 AdminPassword: !Ref AdminPassword,
                 UserName: !Ref UserName,
-                DnsIp1: !GetAtt Prep.DnsIpAddress1,
-                DnsIp2: !GetAtt Prep.DnsIpAddress2,
                 DomainCertificateSecretArn: !Ref DomainCertificateSecret,
                 DomainPrivateKeySecretArn: !Ref DomainPrivateKeySecret,
                 LDIFS3Path: !Ref LDIFS3Path,
@@ -787,6 +778,20 @@ Resources:
       DomainName: !Ref DomainName
       DomainCertificateSecretArn: !Ref DomainCertificateSecret
       DomainPrivateKeySecretArn: !Ref DomainPrivateKeySecret
+
+  DhcpOptions:
+    Type: AWS::EC2::DHCPOptions
+    Properties:
+      DomainName: !Ref DomainName
+      DomainNameServers: 
+        - !GetAtt Prep.DnsIpAddress1
+        - !GetAtt Prep.DnsIpAddress2
+
+  VPCDHCPOptionsAssociation:
+    Type: AWS::EC2::VPCDHCPOptionsAssociation
+    Properties: 
+      DhcpOptionsId: !GetAtt DhcpOptions.DhcpOptionsId
+      VpcId: !If [CreateVPC, !Ref PclusterVpc, !Ref Vpc ]
 
   CleanupLambdaRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This adds a DHCP option set to the VPC so that the domain controllers become the primary DNS servers. These servers also use AWS DNS by default, so if the server can not resolve the DNS, it will revert to the  default AWS DNS server, which was the DNS server used previous to the change (Defined in the default DHCP Option set on a VPC).

Due to this change, we no longer need to modify /etc/resolv.conf on the linux instance, as having the dhcp option set defined takes care of this for you at instance boot. This now allows all instances in the VPC resolve the AD DNS.

This was tested by launching the stack, performing adcli commands on the linux instance to ensure they still work, and launching a RES environment to confirm that it works with the configuration.

This has not been tested against Parallel Cluster and it would be recommended to test against PC to ensure it still works as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
