### PR TITLE
Modify dhcp option set

### DIFF
--- a/recipes/dir/demo_managed_ad/assets/main-import.yaml
+++ b/recipes/dir/demo_managed_ad/assets/main-import.yaml
@@ -74,6 +74,9 @@ Parameters:
     Type: String
     Default: hpc-networking
 
+Conditions: 
+  isUSEast1: !Equals [!Ref "AWS::Region", "us-east-1"]
+
 Transform: AWS::Serverless-2016-10-31
 
 Resources:
@@ -371,10 +374,15 @@ Resources:
   DhcpOptions:
     Type: AWS::EC2::DHCPOptions
     Properties:
-      DomainName: !Ref DomainName
+      DomainName: 
+        !If 
+          - isUSEast1 
+          - "ec2.internal"
+          - !Join [ ".", [!Ref "AWS::Region", "compute.internal"]]
       DomainNameServers: 
         - !GetAtt Prep.DnsIpAddress1
         - !GetAtt Prep.DnsIpAddress2
+        - AmazonProvidedDNS
 
   VPCDHCPOptionsAssociation:
     Type: AWS::EC2::VPCDHCPOptionsAssociation

--- a/recipes/dir/demo_managed_ad/assets/main.yaml
+++ b/recipes/dir/demo_managed_ad/assets/main.yaml
@@ -88,6 +88,7 @@ Conditions:
   CreateVPC: !Equals [!Ref Vpc, '']
   # CreateAD: !Equals [!Ref Ad, '']
   CreateAD: !Equals ['', '']
+  isUSEast1: !Equals [!Ref "AWS::Region", "us-east-1"]
 
 Resources:
   DisableImdsv1LaunchTemplate:
@@ -796,10 +797,15 @@ Resources:
   DhcpOptions:
     Type: AWS::EC2::DHCPOptions
     Properties:
-      DomainName: !Ref DomainName
+      DomainName:
+        !If 
+          - isUSEast1 
+          - "ec2.internal"
+          - !Join [ ".", [!Ref "AWS::Region", "compute.internal"]]
       DomainNameServers: 
         - !GetAtt Prep.DnsIpAddress1
         - !GetAtt Prep.DnsIpAddress2
+        - AmazonProvidedDNS
 
   VPCDHCPOptionsAssociation:
     Type: AWS::EC2::VPCDHCPOptionsAssociation


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changing DHCP option set to re-include AmazonProvidedDNS and use the default aws suffix for unqualified domains. This is due to some issues with DNS resolution after doing further testing. The first being that the ManagedAD domain servers could not resolve the private hosted zone in the same VPC, and the second being a failure to connect to virtual desktops using dcv, possible because they attempt to connect using an unqualified domain, and the wrong domain was being used as the search domain.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
