### PR TITLE
Add net support for eu-west-2, eu-west-3, ap-southeast-1, ap-south…

### DIFF
--- a/recipes/net/hpc_large_scale/assets/main.yaml
+++ b/recipes/net/hpc_large_scale/assets/main.yaml
@@ -64,6 +64,14 @@ Mappings:
       ZoneId1: euw1-az1
       ZoneId2: euw1-az2
       ZoneId3: euw1-az3
+    eu-west-2:
+      ZoneId1: euw2-az2
+      ZoneId2: euw2-az3
+      ZoneId3: euw2-az1
+    eu-west-3:
+      ZoneId1: euw3-az1
+      ZoneId2: euw3-az2
+      ZoneId3: euw3-az3
     eu-north-1:
       ZoneId1: eun1-az2
       ZoneId2: eun1-az1
@@ -92,6 +100,14 @@ Mappings:
       ZoneId1: aps1-az2
       ZoneId2: aps1-az3
       ZoneId3: aps1-az1
+    ap-southeast-1:
+      ZoneId1: apse1-az1
+      ZoneId2: apse1-az2
+      ZoneId3: apse1-az3
+    ap-southeast-2:
+      ZoneId1: apse2-az3
+      ZoneId2: apse2-az1
+      ZoneId3: apse2-az2
 
 Resources:
 


### PR DESCRIPTION
*Description of changes:*
Adding net az mapping support for eu-west-2, eu-west-3, ap-southeast-1, ap-southeast-2

Zone/AZ information taken from *aws ec2 describe-availability-zones --region region*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
