### PR TITLE
add instance type as a parameter with t3.micro being the default

### DIFF
--- a/recipes/dir/demo_managed_ad/assets/main-import.yaml
+++ b/recipes/dir/demo_managed_ad/assets/main-import.yaml
@@ -10,6 +10,7 @@ Metadata:
           - DomainName
           - AdminPassword
           - ServiceAccountPassword
+          - AdDomainAdminNodeInstancetype
       - Label:
           default: "Default Active Directory User(s)"
         Parameters:
@@ -73,6 +74,10 @@ Parameters:
     Description: Name of the HPC large-scale networking stack. Requires stackname-PrivateSubnets export.
     Type: String
     Default: hpc-networking
+  AdDomainAdminNodeInstancetype:
+    Description: ec2 instance type for the AdDomainAdminNode
+    Type: String
+    Default: t3.micro
 
 Conditions: 
   isUSEast1: !Equals [!Ref "AWS::Region", "us-east-1"]
@@ -299,7 +304,8 @@ Resources:
       IamInstanceProfile:
         Ref: JoinProfile
       ImageId: !Ref AdminNodeAmiId
-      InstanceType: t2.micro
+      InstanceType:
+        Ref: AdDomainAdminNodeInstancetype
       KeyName: !Ref Keypair
       LaunchTemplate:
         LaunchTemplateId: !Ref 'DisableImdsv1LaunchTemplate'

--- a/recipes/dir/demo_managed_ad/assets/main.yaml
+++ b/recipes/dir/demo_managed_ad/assets/main.yaml
@@ -11,6 +11,7 @@ Metadata:
           - AdminPassword
           - ServiceAccountName
           - ServiceAccountPassword
+          - AdDomainAdminNodeInstancetype
       - Label:
           default: "Default Active Directory User(s)"
         Parameters:
@@ -81,6 +82,10 @@ Parameters:
     Description: AMI for the Admin Node
     Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
     Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+  AdDomainAdminNodeInstancetype:
+    Description: ec2 instance type for the AdDomainAdminNode
+    Type: String
+    Default: t3.micro
 
 Transform: AWS::Serverless-2016-10-31
 
@@ -401,7 +406,8 @@ Resources:
       IamInstanceProfile:
         Ref: JoinProfile
       ImageId: !Ref AdminNodeAmiId
-      InstanceType: t2.micro
+      InstanceType:
+        Ref: AdDomainAdminNodeInstancetype
       KeyName: !Ref Keypair
       LaunchTemplate:
         LaunchTemplateId: !Ref 'DisableImdsv1LaunchTemplate'

--- a/recipes/security/public_certs/assets/main.yaml
+++ b/recipes/security/public_certs/assets/main.yaml
@@ -13,6 +13,10 @@ Metadata:
         Parameters:
           - SubnetId
           - AdminNodeAmiId
+      - Label:
+          default: "Certificate Node"
+        Parameters:
+          - CertificateNodeInstancetype
 
 Parameters:
   DomainName:
@@ -27,6 +31,10 @@ Parameters:
     Description: AMI for the Admin Node
     Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
     Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+  CertificateNodeInstancetype:
+    Description: ec2 instance type for the CertificateNode
+    Type: String
+    Default: t3.micro
 
 Transform: AWS::Serverless-2016-10-31
 
@@ -119,7 +127,8 @@ Resources:
       IamInstanceProfile:
         Ref: InstanceProfile
       ImageId: !Ref AdminNodeAmiId
-      InstanceType: t2.micro
+      InstanceType:
+        Ref: CertificateNodeInstancetype
       LaunchTemplate:
         LaunchTemplateId: !Ref 'DisableImdsv1LaunchTemplate'
         Version: !GetAtt 'DisableImdsv1LaunchTemplate.LatestVersionNumber'


### PR DESCRIPTION
*Description of changes:*

When testing a stack creation in ap-south-1c, I had a failure because t2.micro was not a supported instance type.

t3.micro is now a more commonly supported instance type in most regions/AZs rather than t2.micro.
This change sets t3.micro as the default instance type and adds it as a stack parameter.

I used the following to get a list of t-series types for a list of regions/AZs.

```
aws ec2 describe-instance-type-offerings --location-type "availability-zone" --filters Name=location,Values="$region""$az" --region $region --query "InstanceTypeOfferings[*].[InstanceType]" --output text | sort|grep '^t'* 
```

From the output, it appears that ap-south-1c does not support t2.micro.

*Testing*

* created a stack with recipes/dir/demo_managed_ad/assets/main.yaml using defaults and confirmed that  a t3.micro for AdDomainAdminNode was successfully launched

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
