### PR TITLE
public_certs: Use acmesh-official/acme.sh.git

### DIFF
--- a/recipes/security/public_certs/assets/main.yaml
+++ b/recipes/security/public_certs/assets/main.yaml
@@ -160,7 +160,7 @@ Resources:
 
               mkdir certificates
               cd certificates
-              git clone https://github.com/Neilpang/acme.sh.git
+              git clone https://github.com/acmesh-official/acme.sh.git
               cd acme.sh
               ./acme.sh --install
               ./acme.sh --set-default-ca --server letsencrypt


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The [README for `recipes/security/public_certs`](https://github.com/aws-samples/aws-hpc-recipes/blob/d2dd90264197c169d75a37bfb70277946e01b7bc/recipes/security/public_certs/README.md) links to https://github.com/acmesh-official/acme.sh.git but the main.yaml CloudFormation template uses the old https://github.com/Neilpang/acme.sh.git

This PR changes main.yaml to use https://github.com/acmesh-official/acme.sh.git

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
