### PR TITLE
Installing already installed packages throws error on RHEL based OS

### DIFF
--- a/recipes/pcs/hpc_ready_ami/assets/scripts/install-cloudwatch-agent.sh
+++ b/recipes/pcs/hpc_ready_ami/assets/scripts/install-cloudwatch-agent.sh
@@ -38,7 +38,7 @@ handle_rhel_9() {
     elif [ "${ARCHITECTURE}" == "x86_64" ]; then
         TARGET="amd64"
     fi
-    sudo dnf install -y "https://amazoncloudwatch-agent.s3.amazonaws.com/redhat/${TARGET}/latest/amazon-cloudwatch-agent.rpm"
+    dnf list installed amazon-cloudwatch-agent || sudo dnf install -y "https://amazoncloudwatch-agent.s3.amazonaws.com/redhat/${TARGET}/latest/amazon-cloudwatch-agent.rpm"
 }
 
 handle_rocky_9() {
@@ -48,7 +48,7 @@ handle_rocky_9() {
     elif [ "${ARCHITECTURE}" == "x86_64" ]; then
         TARGET="amd64"
     fi
-    sudo dnf install -y "https://amazoncloudwatch-agent.s3.amazonaws.com/redhat/${TARGET}/latest/amazon-cloudwatch-agent.rpm"
+    dnf list installed amazon-cloudwatch-agent || sudo dnf install -y "https://amazoncloudwatch-agent.s3.amazonaws.com/redhat/${TARGET}/latest/amazon-cloudwatch-agent.rpm"
 }
 
 handle_amzn_2() {

--- a/recipes/pcs/hpc_ready_ami/assets/scripts/install-ssm-agent.sh
+++ b/recipes/pcs/hpc_ready_ami/assets/scripts/install-ssm-agent.sh
@@ -35,7 +35,7 @@ handle_rhel_9() {
     elif [ "${ARCHITECTURE}" == "x86_64" ]; then
         TARGET="linux_amd64"
     fi
-    sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/${TARGET}/amazon-ssm-agent.rpm
+    dnf list installed amazon-ssm-agent || sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/${TARGET}/amazon-ssm-agent.rpm
 }
 
 handle_rocky_9() {
@@ -47,7 +47,7 @@ handle_rocky_9() {
     elif [ "${ARCHITECTURE}" == "x86_64" ]; then
         TARGET="linux_amd64"
     fi
-    sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/${TARGET}/amazon-ssm-agent.rpm
+    dnf list installed amazon-ssm-agent || sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/${TARGET}/amazon-ssm-agent.rpm
 }
 
 handle_amzn_2() {
@@ -59,7 +59,7 @@ handle_amzn_2() {
     elif [ "${ARCHITECTURE}" == "x86_64" ]; then
         TARGET="linux_amd64"
     fi
-    sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/${TARGET}/amazon-ssm-agent.rpm
+    yum list installed amazon-ssm-agent || sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/${TARGET}/amazon-ssm-agent.rpm
 }
 
 # Main function


### PR DESCRIPTION
Installing already installed packages from explicit http locations fails. We
need to check whether is already installed since the return code of
`install-ssm-agent.sh` and other scripts reflects whether the ImageBuilder
components succeeded or failed.

-------

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.