### PR TITLE
Fix adding C-state kernel parameters

### DIFF
--- a/recipes/pcs/hpc_ready_ami/assets/components/install-cloudwatch-agent.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/components/install-cloudwatch-agent.yaml
@@ -43,12 +43,14 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh -o common.sh'
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-cloudwatch-agent.sh -o install-cloudwatch-agent.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-cloudwatch-agent.sh'
                     - './install-cloudwatch-agent.sh'
 

--- a/recipes/pcs/hpc_ready_ami/assets/components/install-efa.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/components/install-efa.yaml
@@ -49,11 +49,13 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-efa.sh -o install-efa.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-efa.sh'
                     - './install-efa.sh --efa-installer-version={{ EfaVersion }}'
 

--- a/recipes/pcs/hpc_ready_ami/assets/components/install-efs-utils.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/components/install-efs-utils.yaml
@@ -43,12 +43,14 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh -o common.sh'
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-efs-utils.sh -o install-efs-utils.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-efs-utils.sh'
                     - './install-efs-utils.sh'
 

--- a/recipes/pcs/hpc_ready_ami/assets/components/install-lustre.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/components/install-lustre.yaml
@@ -44,12 +44,14 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh -o common.sh'
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-lustre.sh -o install-lustre.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-lustre.sh'
                     - './install-lustre.sh'
 

--- a/recipes/pcs/hpc_ready_ami/assets/components/install-pcs-agent.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/components/install-pcs-agent.yaml
@@ -49,11 +49,13 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-pcs-agent.sh -o install-pcs-agent.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-pcs-agent.sh'
                     - './install-pcs-agent.sh --aws-region=${AWS::Region} --pcs-agent-installer-version={{ PcsAgentInstallerVersion }}'
 

--- a/recipes/pcs/hpc_ready_ami/assets/components/install-pcs-slurm.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/components/install-pcs-slurm.yaml
@@ -53,11 +53,13 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-pcs-slurm.sh -o install-pcs-slurm.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-pcs-slurm.sh'
                     - './install-pcs-slurm.sh --aws-region=${AWS::Region} --pcs-slurm-version={{ PcsSlurmVersion }} --pcs-slurm-installer-version={{ PcsSlurmInstallerVersion }}'
 

--- a/recipes/pcs/hpc_ready_ami/assets/components/install-spack.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/components/install-spack.yaml
@@ -49,12 +49,14 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh -o common.sh'
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-spack.sh -o install-spack.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-spack.sh'
                     - './install-spack.sh --prefix={{ Prefix }}'
 

--- a/recipes/pcs/hpc_ready_ami/assets/components/install-ssm-agent.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/components/install-ssm-agent.yaml
@@ -43,12 +43,14 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh -o common.sh'
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-ssm-agent.sh -o install-ssm-agent.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-ssm-agent.sh'
                     - './install-ssm-agent.sh'
 Outputs:

--- a/recipes/pcs/hpc_ready_ami/assets/components/optimize-performance.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/components/optimize-performance.yaml
@@ -43,12 +43,14 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh -o common.sh'
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/optimize-performance.sh -o optimize-performance.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x optimize-performance.sh'
                     - './optimize-performance.sh'
 

--- a/recipes/pcs/hpc_ready_ami/assets/components/update-os.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/components/update-os.yaml
@@ -43,12 +43,14 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh -o common.sh'
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/update-os.sh -o update-os.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x update-os.sh'
                     - './update-os.sh'
 

--- a/recipes/pcs/hpc_ready_ami/assets/imagebuilder-components.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/imagebuilder-components.yaml
@@ -48,11 +48,13 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-pcs-agent.sh -o install-pcs-agent.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-pcs-agent.sh'
                     - './install-pcs-agent.sh --aws-region=${AWS::Region} --pcs-agent-installer-version={{ PcsAgentInstallerVersion }}'
 
@@ -82,11 +84,13 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-pcs-slurm.sh -o install-pcs-slurm.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-pcs-slurm.sh'
                     - './install-pcs-slurm.sh --aws-region=${AWS::Region} --pcs-slurm-version={{ PcsSlurmVersion }} --pcs-slurm-installer-version={{ PcsSlurmInstallerVersion }}'
 
@@ -112,11 +116,13 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-efa.sh -o install-efa.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-efa.sh'
                     - './install-efa.sh --efa-installer-version={{ EfaVersion }}'
 
@@ -142,12 +148,14 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh -o common.sh'
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-spack.sh -o install-spack.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-spack.sh'
                     - './install-spack.sh --prefix={{ Prefix }}'
 
@@ -168,12 +176,14 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh -o common.sh'
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/update-os.sh -o update-os.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x update-os.sh'
                     - './update-os.sh'
 
@@ -194,12 +204,14 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh -o common.sh'
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-efs-utils.sh -o install-efs-utils.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-efs-utils.sh'
                     - './install-efs-utils.sh'
 
@@ -220,12 +232,14 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh -o common.sh'
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-lustre.sh -o install-lustre.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-lustre.sh'
                     - './install-lustre.sh'
 
@@ -246,12 +260,14 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh -o common.sh'
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-cloudwatch-agent.sh -o install-cloudwatch-agent.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-cloudwatch-agent.sh'
                     - './install-cloudwatch-agent.sh'
 
@@ -272,12 +288,14 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh -o common.sh'
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-ssm-agent.sh -o install-ssm-agent.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x install-ssm-agent.sh'
                     - './install-ssm-agent.sh'
 
@@ -298,11 +316,13 @@ Resources:
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh -o common.sh'
                     - 'curl -fsSL https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/optimize-performance.sh -o optimize-performance.sh'
               - name: InstallAgent
                 action: ExecuteBash
                 inputs:
                   commands:
+                    - set -e
                     - 'chmod +x optimize-performance.sh'
                     - './optimize-performance.sh'

--- a/recipes/pcs/hpc_ready_ami/assets/scripts/optimize-performance.sh
+++ b/recipes/pcs/hpc_ready_ami/assets/scripts/optimize-performance.sh
@@ -49,11 +49,10 @@ disable_deeper_cstates() {
         logger "Disabling deeper C-States" "INFO"
 
         GRUB_COMMAND="grub2-mkconfig -o /boot/grub2/grub.cfg"
-        GRUB_SUB='s/^GRUB_CMDLINE_LINUX_DEFAULT=".*"/GRUB_CMDLINE_LINUX_DEFAULT="intel_idle.max_cstate=0 processor.max_cstate=1"/'
-
+        GRUB_SUB='/^GRUB_CMDLINE_LINUX_DEFAULT=".*"$/s/"$/ intel_idle.max_cstate=0 processor.max_cstate=1"/'
         if [ "${OS}" == "ubuntu" ]; then
             GRUB_COMMAND="/usr/sbin/update-grub"
-            GRUB_SUB='s/^GRUB_CMDLINE_LINUX=".*"/GRUB_CMDLINE_LINUX="intel_idle.max_cstate=0 processor.max_cstate=1"/'
+            GRUB_SUB='/^GRUB_CMDLINE_LINUX=".*"$/s/"$/ intel_idle.max_cstate=0 processor.max_cstate=1"/'
         fi
 
         sudo sed -i "${GRUB_SUB}" /etc/default/grub

--- a/recipes/pcs/hpc_ready_ami/assets/scripts/optimize-performance.sh
+++ b/recipes/pcs/hpc_ready_ami/assets/scripts/optimize-performance.sh
@@ -29,12 +29,16 @@ disable_select_cron_tasks() {
 
     if [ -d "/etc/cron.daily" ]; then
         for task in man-db man-db.cron mlocate; do
-            grep -qxF "$task" "/etc/cron.daily/jobs.deny" || sudo echo "$task" | sudo tee -a "/etc/cron.daily/jobs.deny" > /dev/null
+            if [ ! -f "/etc/cron.daily/jobs.deny" ] || ! grep -qxF "$task" "/etc/cron.daily/jobs.deny"; then
+               echo "$task" | sudo tee -a "/etc/cron.daily/jobs.deny" > /dev/null
+            fi
         done
     fi
     if [ -d "/etc/cron.weekly" ]; then
         for task in man-db; do
-            grep -qxF "$task" "/etc/cron.daily/jobs.weekly" || sudo echo "$task" | sudo tee -a "/etc/cron.daily/jobs.weekly" > /dev/null
+            if [ ! -f "/etc/cron.daily/jobs.weekly" ] || ! grep -qxF "$task" "/etc/cron.daily/jobs.weekly"; then
+                echo "$task" | sudo tee -a "/etc/cron.daily/jobs.weekly" > /dev/null
+            fi
         done
     fi
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
    - Changed the `sed` commands to add the new parameters instead of overwriting the existing `cmdline`.
      - Add `set -e` to all ImageBuilder ExecuteBash actions to relay the exit code of the individual install scripts.
      - Check whether `cron` files exists *before* runnign `grep -q` since `pipefail` is enabled.
      - Use `grubby` for RHEL-9 and rocky-9 in accridance with https://github.com/aws/aws-parallelcluster-cookbook/commit/1f5911817d10b9ca00a706c94d50ef5e756b81e7.
      

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.