### PR TITLE
python3-pip no longer a dependency for spack/postinstall.sh

### DIFF
--- a/recipes/pcs/hpc_ready_ami/assets/scripts/install-spack.sh
+++ b/recipes/pcs/hpc_ready_ami/assets/scripts/install-spack.sh
@@ -81,22 +81,22 @@ download_and_install_spack() {
 
 handle_ubuntu_22.04() {
     logger "Installing deps for Ubuntu 22.04" "INFO"
-    sudo apt update && sudo apt install -y git python3-pip unzip && sudo apt clean
+    sudo apt update && sudo apt install -y git unzip && sudo apt clean
 }
 
 handle_rhel_9() { 
     logger "Installing deps for RHEL 9" "INFO"
-    sudo dnf install -y git python3-pip && sudo dnf clean all
+    sudo dnf install -y git && sudo dnf clean all
 }
 
 handle_rocky_9() {
     logger "Installing deps for Rocky Linux 9" "INFO"
-    sudo dnf install -y git python3-pip && sudo dnf clean all
+    sudo dnf install -y git && sudo dnf clean all
 }
 
 handle_amzn_2() {
     logger "Installing deps for Amazon Linux 2" "INFO"
-    sudo yum makecache && sudo yum install -y git python3-pip && sudo yum clean all
+    sudo yum makecache && sudo yum install -y git && sudo yum clean all
 }
 
 # Main function


### PR DESCRIPTION
Removed in
https://github.com/spack/spack-configs/commit/f8ab2987a045abbcaa2c1b90ec88f49f0ec26a19

-------

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.