### PR TITLE
Remove ocsp-must-staple argument when issuing certificates

### DIFF
--- a/recipes/pcs/hpc_ready_ami/assets/scripts/install-spack.sh
+++ b/recipes/pcs/hpc_ready_ami/assets/scripts/install-spack.sh
@@ -81,22 +81,22 @@ download_and_install_spack() {
 
 handle_ubuntu_22.04() {
     logger "Installing deps for Ubuntu 22.04" "INFO"
-    sudo apt update && sudo apt install -y git python3-pip unzip && sudo apt clean
+    sudo apt update && sudo apt install -y git unzip && sudo apt clean
 }
 
 handle_rhel_9() { 
     logger "Installing deps for RHEL 9" "INFO"
-    sudo dnf install -y git python3-pip && sudo dnf clean all
+    sudo dnf install -y git && sudo dnf clean all
 }
 
 handle_rocky_9() {
     logger "Installing deps for Rocky Linux 9" "INFO"
-    sudo dnf install -y git python3-pip && sudo dnf clean all
+    sudo dnf install -y git && sudo dnf clean all
 }
 
 handle_amzn_2() {
     logger "Installing deps for Amazon Linux 2" "INFO"
-    sudo yum makecache && sudo yum install -y git python3-pip && sudo yum clean all
+    sudo yum makecache && sudo yum install -y git && sudo yum clean all
 }
 
 # Main function

--- a/recipes/security/public_certs/assets/main.yaml
+++ b/recipes/security/public_certs/assets/main.yaml
@@ -168,7 +168,7 @@ Resources:
               cd acme.sh-$VERSION
               ./acme.sh --install
               ./acme.sh --set-default-ca --server letsencrypt
-              ./acme.sh --issue --dns dns_aws --ocsp-must-staple --keylength 4096  -d ${DomainName} -d "*.${DomainName}"
+              ./acme.sh --issue --dns dns_aws --keylength 4096  -d ${DomainName} -d "*.${DomainName}"
 
               CERTKEYFILE=$HOME/.acme.sh/${DomainName}/${DomainName}.key
               CERTCERFILE=$HOME/.acme.sh/${DomainName}/${DomainName}.cer
@@ -322,7 +322,7 @@ Resources:
                   cd acme.sh-$VERSION
                   ./acme.sh --install
                   ./acme.sh --set-default-ca --server letsencrypt
-                  ./acme.sh --issue --dns dns_aws --ocsp-must-staple --keylength 4096  -d ${DomainName} -d "*.${DomainName}"
+                  ./acme.sh --issue --dns dns_aws --keylength 4096  -d ${DomainName} -d "*.${DomainName}"
 
                   CERTKEYFILE=$HOME/.acme.sh/${DomainName}/${DomainName}.key
                   CERTCERFILE=$HOME/.acme.sh/${DomainName}/${DomainName}.cer


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removed --ocsp-must-staple argument from CertificateNode user script and CertificateRenewalLambda code, as LetsEncrypt has sunset support for OCSP Stapling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
