### PR TITLE
fixing cloudformation environment variable substitution

### DIFF
--- a/recipes/pcs/login_node_for_res/assets/imagebuilder-components.yml
+++ b/recipes/pcs/login_node_for_res/assets/imagebuilder-components.yml
@@ -128,6 +128,7 @@ Resources:
                         chmod 0600 /etc/slurm/slurm.key
                         chown slurm:slurm /etc/slurm/slurm.key
 
+                        mkdir -p /etc/sysconfig/
                         echo "SACKD_OPTIONS='--conf-server=${!slurm_ip}:${!slurm_port}'" > /etc/sysconfig/sackd
 
                         sudo cat << EOF > /etc/systemd/system/sackd.service

--- a/recipes/pcs/login_node_for_res/assets/imagebuilder-components.yml
+++ b/recipes/pcs/login_node_for_res/assets/imagebuilder-components.yml
@@ -128,7 +128,7 @@ Resources:
                         chmod 0600 /etc/slurm/slurm.key
                         chown slurm:slurm /etc/slurm/slurm.key
 
-                        echo "SACKD_OPTIONS='--conf-server=${slurm_ip}:${slurm_port}'" > /etc/sysconfig/sackd
+                        echo "SACKD_OPTIONS='--conf-server=${!slurm_ip}:${!slurm_port}'" > /etc/sysconfig/sackd
 
                         sudo cat << EOF > /etc/systemd/system/sackd.service
                         [Unit]
@@ -144,7 +144,7 @@ Resources:
                         Group=slurm
                         RuntimeDirectory=slurm
                         RuntimeDirectoryMode=0755
-                        ExecStart=/opt/aws/pcs/scheduler/slurm-${slurm_version}/sbin/sackd --systemd \$SACKD_OPTIONS
+                        ExecStart=/opt/aws/pcs/scheduler/slurm-${!slurm_version}/sbin/sackd --systemd \$SACKD_OPTIONS
                         ExecReload=/bin/kill -HUP \$MAINPID
                         KillMode=process
                         LimitNOFILE=131072


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Small change to fix the creation of imagebuilder components for RES-ready PCS loginnode instructions listed here: https://github.com/aws-samples/aws-hpc-recipes/tree/main/recipes/pcs/login_node_for_res

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
