### PR TITLE
RES bastion host ssh setup

### DIFF
--- a/recipes/res/bastion_host_ssh_list/README.md
+++ b/recipes/res/bastion_host_ssh_list/README.md
@@ -1,0 +1,19 @@
+
+## Purpose
+
+The aim of this script is to setup the bastion host so that when a user logs in to it, they will see a list of their currently running virtual desktops. This then allows them to ssh to the virtual desktop they want to access.
+
+## Instructions
+
+1. Attach the policy `AmazonEC2ReadOnlyAccess` to the IAM role of the Bastian host. Alternatively you can create a new role that only allows to the [EC2 DescribeInstances API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html).
+
+2. Copy the find_user_instances.sh file to the Bastian host, and run the below commands
+
+```bash
+chmod +x ./find_user_instances.sh
+sudo cp ./find_user_instances.sh /etc/profile.d/find_user_instances.sh
+```
+
+3. Logout and login again - you should see the ip addresses of your instances now show up at login.
+
+4. You should be able to login to any of the listed nodes with ssh.

--- a/recipes/res/bastion_host_ssh_list/find_user_instances.sh
+++ b/recipes/res/bastion_host_ssh_list/find_user_instances.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Script to find EC2 instances with Name tags containing the SSH username
+# and display their private IPs in a table format
+
+# Get the SSH username from the SSH_CLIENT or SSH_CONNECTION environment variable
+# If not available (e.g., when running locally), use the current user
+if [[ -n "$SSH_CLIENT" || -n "$SSH_CONNECTION" ]]; then
+    # Get the username from the SSH session
+    SSH_USER=$(who am i | awk '{print $1}')
+else
+    # Fallback to current user if not in SSH session
+    SSH_USER=$(whoami)
+    echo "Not in SSH session, using current user: $SSH_USER"
+fi
+
+echo "Looking for EC2 instances with names containing: $SSH_USER"
+echo ""
+
+# Check if AWS CLI is installed
+if ! command -v aws &> /dev/null; then
+    echo "Error: AWS CLI is not installed. Please install it first."
+    exit 1
+fi
+
+# Check if jq is installed (for JSON parsing)
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is not installed. Please install it first."
+    exit 1
+fi
+
+# Get all running EC2 instances
+echo "Querying EC2 instances..."
+INSTANCES=$(aws ec2 describe-instances \
+    --filters "Name=instance-state-name,Values=running" \
+    --query "Reservations[*].Instances[*].{InstanceId:InstanceId,PrivateIP:PrivateIpAddress,Name:Tags[?Key=='Name'].Value|[0]}" \
+    --output json)
+
+# Check if the AWS CLI command was successful
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to query EC2 instances. Check your AWS credentials and permissions."
+    exit 1
+fi
+
+# Filter instances where Name tag contains the SSH username and create a table
+MATCHING_INSTANCES=$(echo "$INSTANCES" | jq -r '.[] | .[] | select(.Name != null) | select(.Name | ascii_downcase | contains("'"$(echo $SSH_USER | tr '[:upper:]' '[:lower:]')"'")) | "\(.InstanceId)\t\(.Name)\t\(.PrivateIP)"')
+
+# Check if any matching instances were found
+if [ -z "$MATCHING_INSTANCES" ]; then
+    echo "No EC2 instances found with names containing '$SSH_USER'"
+    exit 0
+fi
+
+# Print the table header
+printf "%-20s %-40s %-15s\n" "INSTANCE ID" "NAME" "PRIVATE IP"
+printf "%-20s %-40s %-15s\n" "----------" "----" "----------"
+
+# Print the table content
+echo "$MATCHING_INSTANCES" | while IFS=$'\t' read -r id name ip; do
+    printf "%-20s %-40s %-15s\n" "$id" "$name" "$ip"
+done
+
+echo ""
+echo "Found $(echo "$MATCHING_INSTANCES" | wc -l | tr -d ' ') instance(s) matching '$SSH_USER'"


### PR DESCRIPTION
*Description of changes:*
A convenient setup that shows users the list of instances when they login to the res bastion host, and the private IPs so they can ssh to an instance of their choice.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
