### PR TITLE
fix: creating instance profile required by stack to succesfully deploy pcs ready ami

### DIFF
--- a/recipes/pcs/hpc_ready_ami/assets/create-pcs-image.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/create-pcs-image.yaml
@@ -93,6 +93,30 @@ Conditions:
     - "ami"
 
 Resources:
+  # IAM Role and Instance Profile for Image Builder
+  ImageBuilderRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/EC2InstanceProfileForImageBuilder
+      Path: /
+
+  ImageBuilderInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: EC2InstanceProfileForImageBuilder
+      Path: /
+      Roles:
+        - !Ref ImageBuilderRole
+
   ImageBuilderComponentsStack:
     Type: AWS::CloudFormation::Stack
     DeletionPolicy: Delete
@@ -142,6 +166,7 @@ Resources:
 
   PCSInfrastructureConfiguration:
     Type: AWS::ImageBuilder::InfrastructureConfiguration
+    DependsOn: ImageBuilderInstanceProfile
     Properties:
       Description: !Sub '${Architecture} infrastructure'
       InstanceProfileName: EC2InstanceProfileForImageBuilder


### PR DESCRIPTION
*Description of changes:*

Adding an IAM instance profile that is not present by default in accounts, but is required for the pcs-ready-ami stack to successfully deploy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
