### PR TITLE
Typos in the login_node_for_res recipe

### DIFF
--- a/recipes/pcs/login_node_for_res/assets/main.yml
+++ b/recipes/pcs/login_node_for_res/assets/main.yml
@@ -59,7 +59,7 @@ Resources:
             - Sid: RESDynamoDBAccess
               Effect: Allow
               Action: "dynamodb:GetItem"
-              Resource: !Sub"arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${RESEnvironment}.cluster-settings"
+              Resource: !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${RESEnvironment}.cluster-settings"
               Condition:
                 ForAllValues:StringLike:
                   "dynamodb:LeadingKeys":
@@ -68,7 +68,7 @@ Resources:
             - Sid: RESS3Access
               Effect: Allow
               Action: "s3:GetObject"
-              Resource: !Sub"arn:${AWS::Partition}:s3:::${RESEnvironment}-cluster-${AWS::Region}-${AWS::AccountId}/idea/vdc/res-ready-install-script-packages/*"
+              Resource: !Sub "arn:${AWS::Partition}:s3:::${RESEnvironment}-cluster-${AWS::Region}-${AWS::AccountId}/idea/vdc/res-ready-install-script-packages/*"
             - Sid: GPUDriverAccess
               Effect: Allow
               Action: 


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
Adding a space in a couple of the resource !Sub lines of the main recipe that were creating parsing errors when trying to use the template.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
