### PR TITLE
Fix: make deploy aware of specific profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clobber: clean $(addsuffix .ph_clobber,$(PROJECTS))
 
 .PHONY: deploy
 deploy:
-	@aws s3 sync --delete --acl public-read \
+	@aws s3 sync --profile ${PROFILE} --delete --acl public-read \
 		--exclude "*" --include "*/assets/*" --exclude "*/.gitkeep" \
 		recipes s3://${S3_BUCKET}/${RELEASE_TAG}/recipes/;\
 


### PR DESCRIPTION
**Issue**:  Deploying recipes to an S3 bucket fails when the AWS default profile is not used.

**Error**: 
```
fatal error: An error occurred (InvalidAccessKeyId) when calling the ListObjectsV2 operation: The AWS Access Key Id you provided does not exist in our records.
make: *** [Makefile:57: deploy] Error 1
```

**Description of changes**: Added an explicit AWS profile to the aws s3 sync command to ensure deployments work when a non-default profile is used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
