### PR TITLE
Fix: Add Missing Golang Dependency DEB Installation to install-efs-utils.sh

### DIFF
--- a/recipes/pcs/hpc_ready_ami/assets/scripts/install-efs-utils.sh
+++ b/recipes/pcs/hpc_ready_ami/assets/scripts/install-efs-utils.sh
@@ -20,7 +20,7 @@ fi
 
 build_and_install_rpm() {
     logger "RPM install from source" "INFO"
-    sudo yum -y install git rpm-build make rust cargo openssl-devel golang
+    sudo yum -y install git rpm-build make rust cargo openssl-devel
     # Create a temporary directory
     local temp_dir=$(mktemp -d)
     cd "$temp_dir" || exit 1

--- a/recipes/pcs/hpc_ready_ami/assets/scripts/install-efs-utils.sh
+++ b/recipes/pcs/hpc_ready_ami/assets/scripts/install-efs-utils.sh
@@ -20,7 +20,7 @@ fi
 
 build_and_install_rpm() {
     logger "RPM install from source" "INFO"
-    sudo yum -y install git rpm-build make rust cargo openssl-devel
+    sudo yum -y install git rpm-build make rust cargo openssl-devel golang
     # Create a temporary directory
     local temp_dir=$(mktemp -d)
     cd "$temp_dir" || exit 1
@@ -35,7 +35,7 @@ build_and_install_rpm() {
 build_and_install_deb() {
     logger "DEB install from source" "INFO"
     sudo apt-get update
-    sudo apt-get -y install git binutils rustc cargo pkg-config libssl-dev
+    sudo apt-get -y install git binutils rustc cargo pkg-config libssl-dev golang-go
     # Create a temporary directory
     local temp_dir=$(mktemp -d)
     cd "$temp_dir" || exit 1


### PR DESCRIPTION
*Issue #58 *

*Description of changes:*

Added `golang-go` to the DEB installation command in `install-efs-utils.sh` since EFS utils requires it as a dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
