### PR TITLE
[pcs/byo_login] Add sackd service template for Slurm 25.11

### DIFF
--- a/recipes/pcs/byo_login/README.md
+++ b/recipes/pcs/byo_login/README.md
@@ -11,3 +11,4 @@ Several files in the [`assets`](assets/) directory will be of use.
 * `slurm-24.05-sackd.service` - You can use this template file to create the required `sackd` systemd service for Slurm 24.05. 
 * `slurm-24.11-sackd.service` - You can use this template file to create the required `sackd` systemd service for Slurm 24.11.
 * `slurm-25.05-sackd.service` - You can use this template file to create the required `sackd` systemd service for Slurm 25.05.
+* `slurm-25.11-sackd.service` - You can use this template file to create the required `sackd` systemd service for Slurm 25.11.

--- a/recipes/pcs/byo_login/assets/slurm-25.11-sackd.service
+++ b/recipes/pcs/byo_login/assets/slurm-25.11-sackd.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Slurm auth and cred kiosk daemon
+After=network-online.target remote-fs.target
+Wants=network-online.target
+ConditionPathExists=/etc/sysconfig/sackd
+
+[Service]
+Type=notify
+EnvironmentFile=/etc/sysconfig/sackd
+User=slurm
+Group=slurm
+RuntimeDirectory=slurm
+RuntimeDirectoryMode=0755
+ExecStart=/opt/aws/pcs/scheduler/slurm-25.11/sbin/sackd --systemd \$SACKD_OPTIONS
+ExecReload=/bin/kill -HUP \$MAINPID
+KillMode=process
+LimitNOFILE=131072
+LimitMEMLOCK=infinity
+LimitSTACK=infinity
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

PCS now defaults to Slurm 25.11. This PR adds the corresponding sackd systemd service template so BYO login nodes can connect to clusters running the latest Slurm version.

## Changes

- Added `recipes/pcs/byo_login/assets/slurm-25.11-sackd.service`
- Updated `recipes/pcs/byo_login/README.md` to document the new template

## Testing

The service file follows the same pattern as existing templates (24.05, 24.11, 25.05) with only the Slurm version path updated in the `ExecStart` directive.