### PR TITLE
Add EESSI to PCS HPC-ready AMI

### DIFF
--- a/recipes/pcs/hpc_ready_ami/README.md
+++ b/recipes/pcs/hpc_ready_ami/README.md
@@ -15,7 +15,7 @@ They are designed to:
 * Install the AWS PCS Agent and Slurm software
 * Install EFA, Lustre, and EFS software
 * Install CloudWatch and SSM agents
-* Install Spack to support complex userland software installations
+* Install Spack and EESSI to support complex userland software installations
 
 They support the Amazon Linux 2, RHEL9, Rocky Linux 9, and Ubuntu 22.04 operating system distributions on x86_64 and arm64 processors.
 

--- a/recipes/pcs/hpc_ready_ami/README.md
+++ b/recipes/pcs/hpc_ready_ami/README.md
@@ -50,7 +50,7 @@ The ImageBuilder components are available as individual templates that deploy a 
     * For **HpcRecipesBranch**, enter the release branch for the HPC Recipes bucket. Unless you are working with a pre-release version of HPC Recipes for AWS, this will be `main`.
 4. Finish creating the stack. 
 5. When the stack's status reaches `CREATE_COMPLETE`, navigate to the [EC2 Image Builder console](https://console.aws.amazon.com/imagebuilder/home#/components).
-    * On the **Components** page, choose **Onwed by me**. Your new ImageBuilder components should be available there. 
+    * On the **Components** page, choose **Owned by me**. Your new ImageBuilder components should be available there. 
 
 #### Deploy a single ImageBuilder component
 

--- a/recipes/pcs/hpc_ready_ami/assets/components/install-eessi.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/components/install-eessi.yaml
@@ -1,0 +1,62 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ImageBuilder Component to install EESSI on an AMI
+
+### Stack metadata
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: HPC Recipes Configuration
+        Parameters:
+          - HpcRecipesS3Bucket
+          - HpcRecipesBranch
+
+Parameters:
+  HpcRecipesS3Bucket:
+    Type: String
+    Default: aws-hpc-recipes
+    Description: HPC Recipes for AWS S3 bucket
+    AllowedValues:
+         - aws-hpc-recipes
+         - aws-hpc-recipes-dev
+  HpcRecipesBranch:
+    Type: String
+    Default: main
+    Description: HPC Recipes for AWS release branch
+    AllowedPattern: '^(?!.*/\.git$)(?!.*/\.)(?!.*\\.\.)[a-zA-Z0-9-_\.]+$'
+
+Resources:
+  EessiInstaller:
+    Type: AWS::ImageBuilder::Component
+    Properties:
+      Name: !Sub 'EessiInstaller-${AWS::StackName}'
+      Description: Install EESSI and optimized configurations
+      Version: '0.0.1'
+      Platform: Linux
+      Data: !Sub |
+        name: 'EESSI installer'
+        schemaVersion: 1.0
+        phases:
+          - name: build
+            steps:
+              - name: DownloadCommon
+                action: WebDownload
+                inputs:
+                  - source: https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/common.sh
+                    destination: common.sh
+              - name: DownloadInstaller
+                action: WebDownload
+                inputs:
+                  - source: https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/scripts/install-eessi.sh
+                    destination: install-eessi.sh
+              - name: InstallEessi
+                action: ExecuteBash
+                inputs:
+                  commands:
+                    - set -e
+                    - 'chmod +x install-eessi.sh'
+                    - './install-eessi.sh'
+
+Outputs:
+  ImageBuilderComponent:
+    Value: !Ref EessiInstaller

--- a/recipes/pcs/hpc_ready_ami/assets/create-pcs-image.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/create-pcs-image.yaml
@@ -153,6 +153,7 @@ Resources:
         - ComponentArn: !GetAtt [ImageBuilderComponentsStack, Outputs.PcsAgentInstallerComponent]
         - ComponentArn: !GetAtt [ImageBuilderComponentsStack, Outputs.PcsSlurmInstallerComponent]
         - ComponentArn: !GetAtt [ImageBuilderComponentsStack, Outputs.SpackInstallerComponent]
+        - ComponentArn: !GetAtt [ImageBuilderComponentsStack, Outputs.EessiInstallerComponent]
         # Tests to confirm that yielded image can successfully boot
         - ComponentArn: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:component/reboot-test-linux/x.x.x'
       Description: Install PCS Agent, SLURM, and other components

--- a/recipes/pcs/hpc_ready_ami/assets/create-pcs-imagepipeline.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/create-pcs-imagepipeline.yaml
@@ -164,6 +164,7 @@ Resources:
         - ComponentArn: !GetAtt [ImageBuilderComponentsStack, Outputs.PcsAgentInstallerComponent]
         - ComponentArn: !GetAtt [ImageBuilderComponentsStack, Outputs.PcsSlurmInstallerComponent]
         - ComponentArn: !GetAtt [ImageBuilderComponentsStack, Outputs.SpackInstallerComponent]
+        - ComponentArn: !GetAtt [ImageBuilderComponentsStack, Outputs.EessiInstallerComponent]
         # Tests to confirm that yielded image can successfully boot
         - ComponentArn: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:component/reboot-test-linux/x.x.x'
       Description: Install PCS Agent, SLURM, and other components

--- a/recipes/pcs/hpc_ready_ami/assets/nested-imagebuilder-components.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/nested-imagebuilder-components.yaml
@@ -195,6 +195,11 @@ Outputs:
     Value: !GetAtt [ SpackInstallerStack, Outputs.ImageBuilderComponent ]
     Export:
       Name: !Sub "${AWS::StackName}-SpackInstallerComponent"
+  EessiInstallerComponent:
+    Description: EessiInstallerComponent
+    Value: !GetAtt [ EessiInstallerStack, Outputs.ImageBuilderComponent ]
+    Export:
+      Name: !Sub "${AWS::StackName}-EessiInstallerComponent"
   SsmAgentComponent:
     Description: SsmAgentComponent
     Value: !GetAtt [ SsmAgentStack, Outputs.ImageBuilderComponent ]

--- a/recipes/pcs/hpc_ready_ami/assets/nested-imagebuilder-components.yaml
+++ b/recipes/pcs/hpc_ready_ami/assets/nested-imagebuilder-components.yaml
@@ -104,6 +104,17 @@ Resources:
       TemplateURL: !Sub 'https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/components/install-spack.yaml'
       TimeoutInMinutes: 10
 
+  EessiInstallerStack:
+    Type: AWS::CloudFormation::Stack
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      Parameters:
+        HpcRecipesS3Bucket: !Ref HpcRecipesS3Bucket
+        HpcRecipesBranch: !Ref HpcRecipesBranch
+      TemplateURL: !Sub 'https://${HpcRecipesS3Bucket}.s3.us-east-1.amazonaws.com/${HpcRecipesBranch}/recipes/pcs/hpc_ready_ami/assets/components/install-eessi.yaml'
+      TimeoutInMinutes: 10
+
   SsmAgentStack:
     Type: AWS::CloudFormation::Stack
     DeletionPolicy: Delete

--- a/recipes/pcs/hpc_ready_ami/assets/packer/template.json
+++ b/recipes/pcs/hpc_ready_ami/assets/packer/template.json
@@ -47,6 +47,7 @@
             "curl -o /opt/packer/scripts/install-pcs-agent.sh https://{{user `hpc_recipes_s3_bucket`}}.s3.us-east-1.amazonaws.com/{{user `hpc_recipes_branch`}}/recipes/pcs/hpc_ready_ami/assets/scripts/install-pcs-agent.sh",
             "curl -o /opt/packer/scripts/install-pcs-slurm.sh https://{{user `hpc_recipes_s3_bucket`}}.s3.us-east-1.amazonaws.com/{{user `hpc_recipes_branch`}}/recipes/pcs/hpc_ready_ami/assets/scripts/install-pcs-slurm.sh",
             "curl -o /opt/packer/scripts/install-spack.sh https://{{user `hpc_recipes_s3_bucket`}}.s3.us-east-1.amazonaws.com/{{user `hpc_recipes_branch`}}/recipes/pcs/hpc_ready_ami/assets/scripts/install-spack.sh",
+            "curl -o /opt/packer/scripts/install-eessi.sh https://{{user `hpc_recipes_s3_bucket`}}.s3.us-east-1.amazonaws.com/{{user `hpc_recipes_branch`}}/recipes/pcs/hpc_ready_ami/assets/scripts/install-eessi.sh",
             "curl -o /opt/packer/scripts/install-ssm-agent.sh https://{{user `hpc_recipes_s3_bucket`}}.s3.us-east-1.amazonaws.com/{{user `hpc_recipes_branch`}}/recipes/pcs/hpc_ready_ami/assets/scripts/install-ssm-agent.sh",
             "curl -o /opt/packer/scripts/optimize-performance.sh https://{{user `hpc_recipes_s3_bucket`}}.s3.us-east-1.amazonaws.com/{{user `hpc_recipes_branch`}}/recipes/pcs/hpc_ready_ami/assets/scripts/optimize-performance.sh",
             "curl -o /opt/packer/scripts/update-os.sh https://{{user `hpc_recipes_s3_bucket`}}.s3.us-east-1.amazonaws.com/{{user `hpc_recipes_branch`}}/recipes/pcs/hpc_ready_ami/assets/scripts/update-os.sh",
@@ -79,6 +80,7 @@
               "bash /opt/packer/scripts/install-pcs-agent.sh",
               "bash /opt/packer/scripts/install-pcs-slurm.sh",
               "bash /opt/packer/scripts/install-spack.sh"
+              "bash /opt/packer/scripts/install-eessi.sh"
           ]
       },
       {

--- a/recipes/pcs/hpc_ready_ami/assets/scripts/install-eessi.sh
+++ b/recipes/pcs/hpc_ready_ami/assets/scripts/install-eessi.sh
@@ -84,7 +84,7 @@ main() {
     parse_args "$@"
     detect_os_version
     handle_${OS}_${VERSION}
-    eessi
+    download_and_install_eessi
 }
 
 # Call the main function

--- a/recipes/pcs/hpc_ready_ami/assets/scripts/install-eessi.sh
+++ b/recipes/pcs/hpc_ready_ami/assets/scripts/install-eessi.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -o errexit -o pipefail -o nounset
+
+# Find the directory of the current script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Search for common.sh in the current directory and parent directory
+if [ -f "${SCRIPT_DIR}/common.sh" ]; then
+    . "${SCRIPT_DIR}/common.sh"
+elif [ -f "${SCRIPT_DIR}/../common.sh" ]; then
+    . "${SCRIPT_DIR}/../common.sh"
+else
+    echo "Error: common.sh not found!" >&2
+    exit 1
+fi
+
+
+# Function to print usage
+usage() {
+    echo "Usage: $0"
+}
+
+# Function to parse command-line arguments
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            *)
+                echo "Invalid option: $1" >&2
+                usage
+                exit 1
+                ;;
+        esac
+        shift
+    done
+}
+
+# Function to download and verify public key
+download_and_verify_pubkey() {
+    echo "Skipping public key download and verification for now"
+}
+
+# Function to download and install CVMFS (and indirectly EESSI)
+download_and_install_eessi() {
+    local temp_dir=$(mktemp -d)
+    cd "$temp_dir" || exit 1
+
+    # Download EESSI install script from EESSI/eessi-demo
+    curl -fsSL "https://raw.githubusercontent.com/EESSI/eessi-demo/refs/heads/main/scripts/install_cvmfs_eessi.sh" -o "install_cvmfs_eessi.sh"
+
+    chmod a+x install_cvmfs_eessi.sh
+    sudo ./install_cvmfs_eessi.sh
+
+    if [ $? -ne 0 ]; then
+        echo "Error: Installation failed" >&2
+        exit 1
+    else
+        echo "Installation successful"
+    fi
+
+    cd - || exit 1
+    rm -rf "$temp_dir"
+}
+
+handle_ubuntu_22.04() {
+    logger "Installing deps for Ubuntu 22.04" "INFO"
+    sudo apt update && sudo apt install -y lsb-release wget && sudo apt clean
+}
+
+handle_rhel_9() { 
+    logger "Installing deps for RHEL 9" "INFO"
+}
+
+handle_rocky_9() {
+    logger "Installing deps for Rocky Linux 9" "INFO"
+}
+
+handle_amzn_2() {
+    logger "Installing deps for Amazon Linux 2" "INFO"
+}
+
+# Main function
+main() {
+    parse_args "$@"
+    detect_os_version
+    handle_${OS}_${VERSION}
+    eessi
+}
+
+# Call the main function
+main "$@"


### PR DESCRIPTION
*Description of changes:*

I've followed the example of Spack as closely as possible to add support for [EESSI](https://www.eessi.io/docs/) to the images.

I'll try to test this but I imagine this will require changing the files  as the the scripts are not in the S3 bucket until they are merged.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
